### PR TITLE
アクセスにスタジオ位置のgoogleマップを表示

### DIFF
--- a/app/views/accesses/show.html.erb
+++ b/app/views/accesses/show.html.erb
@@ -6,3 +6,7 @@
     place: <%= link_to "四谷LOTUS", "https://yotsuyalotus.com/", target: "_blank", class: "link" %>
   </p>
 </div>
+
+<div class="flex justify-start mx-4 mt-4">
+  <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3240.5595046799267!2d139.71915057629874!3d35.687846872585006!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x60188ced61ccfc2f%3A0x442158dd5310b4ea!2z5Zub6LC3TE9UVVM!5e0!3m2!1sja!2sjp!4v1741525074726!5m2!1sja!2sjp" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+</div>


### PR DESCRIPTION
# 概要
- スタジオ位置がわかるように、Accessの欄にgoogleマップを埋め込み

# 変更点
- googleマップの、スタジオ位置を示すリンクを埋め込む
[![Image from Gyazo](https://i.gyazo.com/17610d7f37d89b668c178bdb2c88fa4c.png)](https://gyazo.com/17610d7f37d89b668c178bdb2c88fa4c)