### PR TITLE
add:サイリウム機能

### DIFF
--- a/app/controllers/psylliums_controller.rb
+++ b/app/controllers/psylliums_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 class PsylliumsController < ApplicationController
+  skip_before_action :authenticate_user!
   def index; end
 end

--- a/app/controllers/psylliums_controller.rb
+++ b/app/controllers/psylliums_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class PsylliumsController < ApplicationController
+  def index; end
+end

--- a/app/views/psylliums/index.html.erb
+++ b/app/views/psylliums/index.html.erb
@@ -1,0 +1,1 @@
+<div class="bg-orange-500 h-[calc(100vh-80px)]"></div>

--- a/app/views/shared/_after_login_header.html.erb
+++ b/app/views/shared/_after_login_header.html.erb
@@ -4,6 +4,9 @@
   <% end %>
   <div class="flex">
     <div>
+      <%= link_to " ",psylliums_index_path,  class: "bg-orange-500 btn btn-ghost btn-md" %>
+    </div>
+    <div>
       <%= link_to "https://ksk.botofune.com/", target: "_blank", class: "btn btn-ghost btn-md" do %>
         <i class="fa-solid fa-bullhorn"></i>
       <% end %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -4,6 +4,9 @@
   <% end %>
   <div class="flex">
     <div>
+      <%= link_to " ",psylliums_index_path,  class: "bg-orange-500 btn btn-ghost btn-md" %>
+    </div>
+    <div>
       <%= link_to "https://ksk.botofune.com/", target: "_blank", class: "btn btn-ghost btn-md" do %>
         <i class="fa-solid fa-bullhorn"></i>
       <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="pr-5">
+<div class="md:pr-5">
   <% if user_signed_in? %>
     <%= render "shared/after_login_header" %>
   <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  get 'psylliums/index'
   get 'static_pages/top'
   devise_for :users, skip: :all
   devise_scope :user do


### PR DESCRIPTION
# 概要
サイリウム機能として、ヘッダーのボタンから画面いっぱいにオレンジ色を表示できる機能を追加しました。
未ログインユーザー、ログインユーザーの両方が使用可能な機能です。

# 細かな変更点
* ヘッダーのレイアウト調整のため、PCサイズ以上の画面の時にpr-5をするようにしています。（app/views/shared/_header.html.erb）

## スクリーンショット
|       | Before | After(1) | After(2) |
| :---: | :----: | :---: | :---: |
|  |![runteq-music-fes onrender com_(iPhone SE)](https://github.com/user-attachments/assets/1368c6ad-f564-4cb1-bf7f-308ac95ef68a) ![runteq-music-fes onrender com_(PC(1280px))](https://github.com/user-attachments/assets/250e9cd1-ebbd-4796-af21-a327ffd2ed71) |  ![localhost_3000_psylliums_index(iPhone SE) (1)](https://github.com/user-attachments/assets/21f7bf87-6efc-451a-8aeb-ded8ba9bb47b) ![localhost_3000_(PC(1280px)) (2)](https://github.com/user-attachments/assets/5eeedaf4-7fb6-43e6-8719-5c3886584bd6)  | ![localhost_3000_psylliums_index(iPhone SE)](https://github.com/user-attachments/assets/41f8049a-7626-4528-ab8f-623d383b8e3e)  ![localhost_3000_(PC(1280px)) (1)](https://github.com/user-attachments/assets/e19dbdcf-9598-41ce-939b-f9bf2dafd2e1) |



# 影響範囲・懸念点

# おこなった動作確認
* [x] ローカルホスト上でPC、iphoneSEサイズの２画面での表示確認をしました。

# 関連issue

# その他
